### PR TITLE
feat: stderr option

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,29 @@ log.info('batman');
 //→ [00:00:00] ⓡ batman
 ```
 
+##### stderr
+
+Type: `Array[string]`<br>
+Default: `['info', 'warn', 'error', 'pass', 'fail']`
+
+Defines the levels which output to `stderr` by default. This setting is useful
+for directing select loggers to output only specific levels to `stderr` while
+allowing other levels to output to `stdout`.
+
+```js
+import { logger } from '@rollup-cabal/log';
+
+const log = logger({ stderr: ['warn', 'error'] });
+
+log.info('batman');
+
+// stdout → ⓡ batman
+
+log.warn('riddler');
+
+// stderr → ⓡ riddler
+```
+
 ### Instance
 
 #### .info(text: `string`)

--- a/src/StdErrorFactory.ts
+++ b/src/StdErrorFactory.ts
@@ -1,17 +1,18 @@
-
 import loglevel from 'loglevelnext';
 
 const { PrefixFactory } = loglevel.factories;
 
 export class StdErrorFactory extends PrefixFactory {
   logger: any;
+  stderr: any[];
 
-  constructor(log: any, prefix: any) {
+  constructor(log: any, prefix: any, stderr: any[]) {
     super(log, prefix);
+    this.stderr = stderr;
   }
 
   bindMethod(obj: any, methodName: string) {
-    const targets = ['info', 'warn', 'error', 'pass', 'fail'];
+    const targets = this.stderr;
     const useName = targets.includes(methodName) ? 'error' : methodName;
 
     return super.bindMethod(obj, useName);
@@ -23,4 +24,4 @@ export class StdErrorFactory extends PrefixFactory {
     this.logger.fail = super.make('fail');
     this.logger.pass = super.make('pass');
   }
-};
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ const enum LogLevel {
   info = 'info',
   warn = 'warn',
   error = 'error'
-};
+}
 
 const colors: Colors = {
   trace: chalk`{cyan ⓡ} `,
@@ -25,12 +25,13 @@ const colors: Colors = {
 
 const defaults: Options = {
   level: LogLevel.info,
-  timestamp: false
+  timestamp: false,
+  stderr: ['info', 'warn', 'error', 'pass', 'fail']
 };
 
 export const logger = (opts?: Options) => {
   const unique = { id: uuid() };
-  const options: Options = {...defaults, ...unique, ...opts};
+  const options: Options = { ...defaults, ...unique, ...opts };
 
   const prefix: Prefix = {
     level: ({ level }: { level: string }) => colors[level],
@@ -47,16 +48,15 @@ export const logger = (opts?: Options) => {
 
   const log = loglevel.getLogger(options);
 
-  log.factory = new StdErrorFactory(log, prefix);
+  log.factory = new StdErrorFactory(log, prefix, options.stderr);
 
   return log;
 };
-
 
 export default logger;
 
 export function deleteLogger(id: string) {
   delete loglevel.loggers[id];
-};
+}
 
 export const factories = loglevel.factories;

--- a/typings/declarations.d.ts
+++ b/typings/declarations.d.ts
@@ -1,0 +1,4 @@
+declare module 'loglevelnext' {
+    var _a: any;
+    export = any;
+}

--- a/typings/loglevelnext.d.ts
+++ b/typings/loglevelnext.d.ts
@@ -1,4 +1,0 @@
-declare module 'loglevelnext' {
-    var _a: any;
-    export = any;
-}

--- a/typings/types.d.ts
+++ b/typings/types.d.ts
@@ -1,6 +1,5 @@
-
 export interface Colors {
-	[key: string]: string;
+  [key: string]: string;
 }
 
 export interface Prefix {
@@ -10,9 +9,10 @@ export interface Prefix {
 
 export interface Options {
   id?: string;
-	level?: LogLevel;
+  level?: LogLevel;
   name?: string;
   preface?: string;
   prefix?: Prefix;
-	timestamp?: boolean;
+  timestamp?: boolean;
+  stderr?: string[];
 }


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains:

- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] tests
- [ ] documentation
- [ ] metadata

### Breaking Changes?

- [ ] yes
- [x] no

If yes, please describe the breakage.

### Please Describe Your Changes

This adds support for different loggers specifying which levels output to stderr. This is going to be useful in addressing issues like https://github.com/rollup/rollup/pull/1232. Multiple loggers can be used or created with different behavior, but _appear to be the same logger_ to users. 

Existing tests cover this feature.